### PR TITLE
Upgrade to FreeBSD 13.2, OPNsense 24.1

### DIFF
--- a/.github/workflows/deploymentChecker-active-active.yml
+++ b/.github/workflows/deploymentChecker-active-active.yml
@@ -45,7 +45,7 @@ env:
   scenarioOption: "Active-Active"
   existingvirtualNetwork: "existing"
   DeployWindows: false
-  OpnScriptURI: "https://raw.githubusercontent.com/dmauser/opnazure/master/scripts/"
+  OpnScriptURI: "https://raw.githubusercontent.com/MakerHe/dmauser-opnazure/master/scripts/"
   DEPNAME: "Dep-OPNsense-Active-Active-${{ github.run_number }}" #Deployment Name
   AZCLIVERSION: 2.36.0 #Pinning to a specific AZ CLI version
 

--- a/.github/workflows/deploymentChecker-newvnet-active-active.yml
+++ b/.github/workflows/deploymentChecker-newvnet-active-active.yml
@@ -45,7 +45,7 @@ env:
   scenarioOption: "Active-Active"
   existingvirtualNetwork: "new"
   DeployWindows: false
-  OpnScriptURI: "https://raw.githubusercontent.com/dmauser/opnazure/master/scripts/"
+  OpnScriptURI: "https://raw.githubusercontent.com/MakerHe/dmauser-opnazure/master/scripts/"
   DEPNAME: "Dep-OPNsense-newvnet-Active-Active-${{ github.run_number }}" #Deployment Name
   AZCLIVERSION: 2.36.0 #Pinning to a specific AZ CLI version
 

--- a/.github/workflows/deploymentChecker-newvnet-two-nics.yml
+++ b/.github/workflows/deploymentChecker-newvnet-two-nics.yml
@@ -45,7 +45,7 @@ env:
   scenarioOption: "TwoNics"
   existingvirtualNetwork: "new"
   DeployWindows: false
-  OpnScriptURI: "https://raw.githubusercontent.com/dmauser/opnazure/master/scripts/"
+  OpnScriptURI: "https://raw.githubusercontent.com/MakerHe/dmauser-opnazure/master/scripts/"
   DEPNAME: "Dep-OPNsense-newvnet-two-nics-${{ github.run_number }}" #Deployment Name
   AZCLIVERSION: 2.36.0 #Pinning to a specific AZ CLI version
 

--- a/.github/workflows/deploymentChecker-two-nics.yml
+++ b/.github/workflows/deploymentChecker-two-nics.yml
@@ -43,7 +43,7 @@ env:
   scenarioOption: "TwoNics"
   existingvirtualNetwork: "existing"
   DeployWindows: false
-  OpnScriptURI: "https://raw.githubusercontent.com/dmauser/opnazure/master/scripts/"
+  OpnScriptURI: "https://raw.githubusercontent.com/MakerHe/dmauser-opnazure/master/scripts/"
   DEPNAME: "Dep-OPNsense-two-nics-${{ github.run_number }}" #Deployment Name
   AZCLIVERSION: 2.36.0 #Pinning to a specific AZ CLI version
 

--- a/ARM/main.json
+++ b/ARM/main.json
@@ -97,7 +97,7 @@
     },
     "OpnScriptURI": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/dmauser/opnazure/master/scripts/",
+      "defaultValue": "https://raw.githubusercontent.com/MakerHe/dmauser-opnazure/master/scripts/",
       "metadata": {
         "description": "URI for Custom OPN Script and Config"
       }
@@ -111,7 +111,7 @@
     },
     "OpnVersion": {
       "type": "string",
-      "defaultValue": "23.1",
+      "defaultValue": "24.1",
       "metadata": {
         "description": "OPN Version"
       }
@@ -962,8 +962,8 @@
                   },
                   "imageReference": {
                     "publisher": "thefreebsdfoundation",
-                    "offer": "freebsd-13_1",
-                    "sku": "13_1-release",
+                    "offer": "freebsd-13_2",
+                    "sku": "13_2-release",
                     "version": "latest"
                   }
                 },
@@ -972,9 +972,9 @@
                 }
               },
               "plan": {
-                "name": "13_1-release",
+                "name": "13_2-release",
                 "publisher": "thefreebsdfoundation",
-                "product": "freebsd-13_1"
+                "product": "freebsd-13_2"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', variables('trustedNicName'))]",
@@ -1427,8 +1427,8 @@
                   },
                   "imageReference": {
                     "publisher": "thefreebsdfoundation",
-                    "offer": "freebsd-13_1",
-                    "sku": "13_1-release",
+                    "offer": "freebsd-13_2",
+                    "sku": "13_2-release",
                     "version": "latest"
                   }
                 },
@@ -1437,9 +1437,9 @@
                 }
               },
               "plan": {
-                "name": "13_1-release",
+                "name": "13_2-release",
                 "publisher": "thefreebsdfoundation",
-                "product": "freebsd-13_1"
+                "product": "freebsd-13_2"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', variables('trustedNicName'))]",
@@ -1893,8 +1893,8 @@
                   },
                   "imageReference": {
                     "publisher": "thefreebsdfoundation",
-                    "offer": "freebsd-13_1",
-                    "sku": "13_1-release",
+                    "offer": "freebsd-13_2",
+                    "sku": "13_2-release",
                     "version": "latest"
                   }
                 },
@@ -1903,9 +1903,9 @@
                 }
               },
               "plan": {
-                "name": "13_1-release",
+                "name": "13_2-release",
                 "publisher": "thefreebsdfoundation",
-                "product": "freebsd-13_1"
+                "product": "freebsd-13_2"
               },
               "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', variables('trustedNicName'))]",

--- a/ARM/main.json
+++ b/ARM/main.json
@@ -969,6 +969,11 @@
                 },
                 "networkProfile": {
                   "networkInterfaces": "[if(equals(parameters('multiNicSupport'), true()), createArray(createObject('id', reference(resourceId('Microsoft.Resources/deployments', variables('untrustedNicName')), '2022-09-01').outputs.nicId.value, 'properties', createObject('primary', true())), createObject('id', reference(resourceId('Microsoft.Resources/deployments', variables('trustedNicName')), '2022-09-01').outputs.nicId.value, 'properties', createObject('primary', false()))), createArray(createObject('id', reference(resourceId('Microsoft.Resources/deployments', variables('untrustedNicName')), '2022-09-01').outputs.nicId.value, 'properties', createObject('primary', true()))))]"
+                },
+                "diagnosticsProfile": {
+                    "bootDiagnostics": {
+                        "enabled": true
+                    }
                 }
               },
               "plan": {
@@ -1434,6 +1439,11 @@
                 },
                 "networkProfile": {
                   "networkInterfaces": "[if(equals(parameters('multiNicSupport'), true()), createArray(createObject('id', reference(resourceId('Microsoft.Resources/deployments', variables('untrustedNicName')), '2022-09-01').outputs.nicId.value, 'properties', createObject('primary', true())), createObject('id', reference(resourceId('Microsoft.Resources/deployments', variables('trustedNicName')), '2022-09-01').outputs.nicId.value, 'properties', createObject('primary', false()))), createArray(createObject('id', reference(resourceId('Microsoft.Resources/deployments', variables('untrustedNicName')), '2022-09-01').outputs.nicId.value, 'properties', createObject('primary', true()))))]"
+                },
+                "diagnosticsProfile": {
+                    "bootDiagnostics": {
+                        "enabled": true
+                    }
                 }
               },
               "plan": {

--- a/ARM/main.parameters.json
+++ b/ARM/main.parameters.json
@@ -38,7 +38,7 @@
       "value": "Standard"
     },
     "OpnScriptURI": {
-      "value": "https://raw.githubusercontent.com/dmauser/opnazure/master/scripts/"
+      "value": "https://raw.githubusercontent.com/MakerHe/dmauser-opnazure/master/scripts/"
     },
     "ShellScriptName": {
       "value": "configureopnsense.sh"

--- a/ARM/uiFormDefinition.json
+++ b/ARM/uiFormDefinition.json
@@ -112,8 +112,8 @@
               "name": "OpnVersion",
               "type": "Microsoft.Common.TextBox",
               "label": "OPNSense Version to deploy",
-              "toolTip": "OPNsense Releases. Latest: 23.1, 23.7 Reference: https://docs.opnsense.org/releases.html",
-              "defaultValue": "23.7"
+              "toolTip": "OPNsense Releases. Latest: 23.1, 23.7, 24.1 Reference: https://docs.opnsense.org/releases.html",
+              "defaultValue": "24.1"
             },
             {
               "name": "WALinuxVersion",

--- a/ARM/uiFormDefinition.json
+++ b/ARM/uiFormDefinition.json
@@ -98,14 +98,14 @@
               "name": "OpnScriptURI",
               "type": "Microsoft.Common.TextBox",
               "label": "URL for OPNSense scritps. All required scripts will be downloaded from this URL and must end with /.",
-              "toolTip": "All scripts must be under this URL path, check the expected content under scripts folder in https://github.com/dmauser/opnazure/tree/master/scripts.",
-              "defaultValue": "https://raw.githubusercontent.com/dmauser/opnazure/master/scripts/"
+              "toolTip": "All scripts must be under this URL path, check the expected content under scripts folder in https://github.com/MakerHe/dmauser-opnazure/tree/master/scripts.",
+              "defaultValue": "https://raw.githubusercontent.com/MakerHe/dmauser-opnazure/master/scripts/"
             },
             {
               "name": "ShellScriptName",
               "type": "Microsoft.Common.TextBox",
               "label": "Bootstrap script name to deploy OPNSense",
-              "toolTip": "The script must be under the previous URL path. Reference: https://github.com/dmauser/opnazure/blob/master/scripts/configureopnsense.sh",
+              "toolTip": "The script must be under the previous URL path. Reference: https://github.com/MakerHe/dmauser-opnazure/blob/master/scripts/configureopnsense.sh",
               "defaultValue": "configureopnsense.sh"
             },
             {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CI Name | Actions Workflow | CI Status |
 
 **Deployment Wizard**
 
-[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fdmauser%2Fopnazure%2Fmaster%2FARM%2Fmain.json%3F/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fdmauser%2Fopnazure%2Fmaster%2Fbicep%2FuiFormDefinition.json)
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMakerHe%2Fdmauser-opnazure%2Fdev%2FARM%2Fmain.json%3F/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FMakerHe%2Fdmauser-opnazure%2Fdev%2Fbicep%2FuiFormDefinition.json)
 
 The template allows you to deploy an OPNsense Firewall VM using the opnsense-bootsrtap installation method. It creates an FreeBSD VM, does a silent install of OPNsense using a modified version of opnsense-bootstrap.sh with the settings provided.
 
@@ -37,6 +37,12 @@ After deployment, you can go to <https://PublicIP>, then input the user and pass
 In case of Active-Active the URL should be <https://PublicIP:50443> for Primary server and <https://PublicIP:50444> for Secondary server.
 
 ## Updates
+
+## Mar-2024
+
+- Updated FreeBSD to 13.2
+- Added support to OPNsense 24.1 (set as default version)
+- Enable Boot diagnostics with managed storage account, change primary console from video to serial.
 
 ## Nov-2023
 

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -43,13 +43,13 @@ param existingTrustedSubnetName string = ''
 param PublicIPAddressSku string = 'Standard'
 
 @sys.description('URI for Custom OPN Script and Config')
-param OpnScriptURI string = 'https://raw.githubusercontent.com/dmauser/opnazure/master/scripts/'
+param OpnScriptURI string = 'https://raw.githubusercontent.com/MakerHe/dmauser-opnazure/master/scripts/'
 
 @sys.description('Shell Script to be executed')
 param ShellScriptName string = 'configureopnsense.sh'
 
 @sys.description('OPN Version')
-param OpnVersion string = '23.1'
+param OpnVersion string = '24.1'
 
 @sys.description('Azure WALinux agent Version')
 param WALinuxVersion string = '2.9.1.1'

--- a/bicep/main.parameters.json
+++ b/bicep/main.parameters.json
@@ -38,7 +38,7 @@
       "value": "Standard"
     },
     "OpnScriptURI": {
-      "value": "https://raw.githubusercontent.com/dmauser/opnazure/master/scripts/"
+      "value": "https://raw.githubusercontent.com/MakerHe/dmauser-opnazure/master/scripts/"
     },
     "ShellScriptName": {
       "value": "configureopnsense.sh"

--- a/bicep/uiFormDefinition.json
+++ b/bicep/uiFormDefinition.json
@@ -112,8 +112,8 @@
               "name": "OpnVersion",
               "type": "Microsoft.Common.TextBox",
               "label": "OPNSense Version to deploy",
-              "toolTip": "OPNsense Releases. Latest: 23.1, 23.7 Reference: https://docs.opnsense.org/releases.html",
-              "defaultValue": "23.7"
+              "toolTip": "OPNsense Releases. Latest: 23.1, 23.7, 24.1 Reference: https://docs.opnsense.org/releases.html",
+              "defaultValue": "24.1"
             },
             {
               "name": "WALinuxVersion",

--- a/bicep/uiFormDefinition.json
+++ b/bicep/uiFormDefinition.json
@@ -98,14 +98,14 @@
               "name": "OpnScriptURI",
               "type": "Microsoft.Common.TextBox",
               "label": "URL for OPNSense scritps. All required scripts will be downloaded from this URL and must end with /.",
-              "toolTip": "All scripts must be under this URL path, check the expected content under scripts folder in https://github.com/dmauser/opnazure/tree/master/scripts.",
-              "defaultValue": "https://raw.githubusercontent.com/dmauser/opnazure/master/scripts/"
+              "toolTip": "All scripts must be under this URL path, check the expected content under scripts folder in https://github.com/MakerHe/dmauser-opnazure/tree/master/scripts.",
+              "defaultValue": "https://raw.githubusercontent.com/MakerHe/dmauser-opnazure/master/scripts/"
             },
             {
               "name": "ShellScriptName",
               "type": "Microsoft.Common.TextBox",
               "label": "Bootstrap script name to deploy OPNSense",
-              "toolTip": "The script must be under the previous URL path. Reference: https://github.com/dmauser/opnazure/blob/master/scripts/configureopnsense.sh",
+              "toolTip": "The script must be under the previous URL path. Reference: https://github.com/MakerHe/dmauser-opnazure/blob/master/scripts/configureopnsense.sh",
               "defaultValue": "configureopnsense.sh"
             },
             {

--- a/scripts/config-active-active-primary.xml
+++ b/scripts/config-active-active-primary.xml
@@ -241,7 +241,7 @@
     <dnsserver>8.8.4.4</dnsserver>
     <sudo_allow_wheel>1</sudo_allow_wheel>
     <serialspeed>115200</serialspeed>
-    <primaryconsole>video</primaryconsole>
+    <primaryconsole>serial</primaryconsole>
     <ssh>
       <enabled>enabled</enabled>
       <passwordauth>1</passwordauth>

--- a/scripts/config-active-active-secondary.xml
+++ b/scripts/config-active-active-secondary.xml
@@ -241,7 +241,7 @@
     <dnsserver>8.8.4.4</dnsserver>
     <sudo_allow_wheel>1</sudo_allow_wheel>
     <serialspeed>115200</serialspeed>
-    <primaryconsole>video</primaryconsole>
+    <primaryconsole>serial</primaryconsole>
     <ssh>
       <enabled>enabled</enabled>
       <passwordauth>1</passwordauth>

--- a/scripts/config.xml
+++ b/scripts/config.xml
@@ -241,7 +241,7 @@
     <dnsserver>8.8.4.4</dnsserver>
     <sudo_allow_wheel>1</sudo_allow_wheel>
     <serialspeed>115200</serialspeed>
-    <primaryconsole>video</primaryconsole>
+    <primaryconsole>serial</primaryconsole>
     <ssh>
       <enabled>enabled</enabled>
       <passwordauth>1</passwordauth>


### PR DESCRIPTION
- Updated FreeBSD to 13.2
- Added support to OPNsense 24.1 (set as default version)
- Enable Boot diagnostics with managed storage account, change primary console from video to serial.